### PR TITLE
因太长而显示不全，添加导航栏二级菜单的title属性

### DIFF
--- a/components/SidebarLink.vue
+++ b/components/SidebarLink.vue
@@ -61,6 +61,9 @@ function renderLink (h, to, text, active, level) {
       activeClass: '',
       exactActiveClass: ''
     },
+    attrs:{
+      title: text
+    },
     class: {
       active,
       'sidebar-link': true


### PR DESCRIPTION
效果图：
> ![image](https://user-images.githubusercontent.com/19749521/83050556-52e12900-a07f-11ea-89ec-c09c6fb7b09b.png)

- 问题：左菜单的二级标题太长，显示内容不完整。
- 我的解决思路：原本想着给所有标题都加，后来发现一级基本都是一个大类不会太长，就只给二级加。三级用的少就没加。（我就怎么简单怎么来了，后续可以尝试优化一下宽度之类的）
- 我看你提供的demo里面基本都是用到了二级。然这个demo也是有同样的问题的。
> ![image](https://user-images.githubusercontent.com/19749521/83051003-f3374d80-a07f-11ea-8452-377ef0ef1e09.png)
（特别是对英文标题尤为严重）
