### PR TITLE
加入对于多语言设置的兼容

### DIFF
--- a/components/NavLinks.vue
+++ b/components/NavLinks.vue
@@ -59,7 +59,11 @@ export default {
     }
   },
   created() {
-    this.routesPath = JSON.stringify(this.$themeConfig.nav)
+    this.routesPath = JSON.stringify(
+      this.$themeConfig.locales
+        ? this.$themeConfig.locales[this.$localePath].nav
+        : this.$themeConfig.nav
+    )
   },
   methods: {
     isExtlink(path) {
@@ -138,11 +142,13 @@ export default {
     },
 
     userLinks() {
-      return (this.nav || []).map(link => {
+      const curNav = (this.nav || []).map(link => {
         return Object.assign(resolveNavLinkItem(link), {
           items: (link.items || []).map(resolveNavLinkItem)
         })
       })
+      this.routesPath = JSON.stringify(curNav)
+      return curNav
     },
 
     repoLink() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37034015/87665667-dd016000-c799-11ea-9f09-b8da57352dbd.png)

问题：使用多语言设置时出现问题，this.$themeConfig.nav 在多语言时可能为undefined；虽然有说明这块功能暂时不支持，但是还是想在这个主题使用，很喜欢Antd的风格

解决思路：原版中 $themeConfig 这个对象有一个属性 locales，里面保存了多语言设置的nav等信息，所以这里修改了原来获取nav 信息方式，根据 locales 属性是否存在来判断是否是多语言情况，利用 $localePath这个属性对应 locales 的 key，来获取当前情况下的 nav 等设置信息，并且把经过修改的 nav 对象重新用 JSON.stringify 处理赋值给 routesPath 保证 Menu的selectedKeys
