### PR TITLE
add-dark-mode

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -11,11 +11,13 @@
           v-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false"
           class="mobile-search"
         />
+        <ThemeSwitcher class="switch-mobile" />
       </a-col>
       <a-col :xs="0" :sm="0" :md="18" :lg="19" :xl="19" :xxl="20">
         <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
         <SearchBox v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false" />
-        <NavLinks class="can-hide" />
+        <ThemeSwitcher class="can-hide" />
+        <NavLinks class="switch-hide" />
       </a-col>
     </a-row>
 
@@ -44,11 +46,13 @@ import SidebarButton from '@theme/components/SidebarButton.vue'
 import NavLinks from '@theme/components/NavLinks.vue'
 import Sidebar from '@theme/components/Sidebar.vue'
 import { resolveSidebarItems } from '../util'
+import ThemeSwitcher from '@theme/components/ThemeSwitcher.vue'
 
 export default {
   name: 'Navbar',
 
   components: {
+    ThemeSwitcher,
     SidebarButton,
     NavLinks,
     SearchBox,
@@ -155,10 +159,20 @@ export default {
     cursor: pointer;
     position: absolute;
     top: 0;
-    left: 0;
+    left: 1.5rem;
     z-index: 2;
   }
+
+  .switch-mobile {
+    display: none;
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 3;
+  }
 }
+
 .sidebarWrap {
   .ant-drawer-content-wrapper {
     width: @sidebarWidth * 0.82 !important;
@@ -249,6 +263,11 @@ export default {
       display: none;
     }
 
+
+    .switch-hide {
+      display: none;
+    }
+
     .links {
       padding-left: 1.5rem;
     }
@@ -266,6 +285,12 @@ export default {
     }
 
     .mobile-search {
+      display: block;
+    }
+
+    .switch-mobile {
+      width: 2rem;
+      padding: 0 0;
       display: block;
     }
   }

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -1,0 +1,52 @@
+<template>
+  <a-button type="primary" @click.prevent="switchTheme()" :aria-label="'Switch to ' + nextTheme + ' mode'">
+    <span key="dark" v-if="theme === 'dark'"><a-icon type="bulb" theme="filled" :style="{ fontSize: '24px', color: 'rgb(230 174 61)' }"/></span>
+    <span key="light" v-else-if="theme === 'light'"><a-icon type="bulb" theme="filled" :style="{ fontSize: '24px', color: 'rgba(0, 0, 0, 0.85)' }"/></span>
+    <span key="light" v-else>Switch</span>
+  </a-button>
+</template>
+
+<script>
+const themes = ['light', 'dark']
+
+export default {
+  name: 'ThemeSwitcher',
+
+  data () {
+    return {
+      theme: ''
+    }
+  },
+
+  computed: {
+    nextTheme () {
+      const currentIndex = themes.indexOf(this.theme)
+      const nextIndex = (currentIndex + 1) % themes.length
+      return themes[nextIndex]
+    }
+  },
+
+  methods: {
+    switchTheme () {
+      const currentIndex = themes.indexOf(this.theme)
+      const nextIndex = (currentIndex + 1) % themes.length
+      window.__setPreferredTheme(themes[nextIndex])
+      this.theme = themes[nextIndex]
+    }
+  },
+
+  async mounted () {
+    // set default
+    if (typeof window.__theme !== 'undefined') {
+      this.theme = window.__theme
+    }
+  }
+}
+</script>
+
+<style lang="less">
+.ant-btn {
+  height: 4rem;
+  margin-right: 0px !important;
+}
+</style>

--- a/global-components/ThemeManager.vue
+++ b/global-components/ThemeManager.vue
@@ -1,0 +1,39 @@
+<template>
+  <div style="visibility: hidden; display: none"></div>
+</template>
+
+<script>
+export default {
+  name: 'ThemeManager',
+
+  beforeMount () {
+    window.__onThemeChange = function () { }
+    function setTheme(newTheme) {
+      window.__theme = newTheme
+      preferredTheme = newTheme
+      document.body.setAttribute('data-theme', newTheme)
+      window.__onThemeChange(newTheme)
+    }
+
+    var preferredTheme
+    try {
+      preferredTheme = localStorage.getItem('theme')
+    } catch (err) { }
+
+    window.__setPreferredTheme = function (newTheme) {
+      setTheme(newTheme)
+      try {
+        localStorage.setItem('theme', newTheme)
+      } catch (err) { }
+    }
+
+    var isColorSchemeDark = window.matchMedia('(prefers-color-scheme: dark)')
+
+    isColorSchemeDark.addListener(function (e) {
+      window.__setPreferredTheme(e.matches ? 'dark' : 'light')
+    })
+
+    setTheme(preferredTheme || (isColorSchemeDark.matches ? 'dark' : 'light'))
+  }
+}
+</script>

--- a/styles/code.less
+++ b/styles/code.less
@@ -1,5 +1,7 @@
 .@{contentClass} {
   code {
+    // color: lighten(@textColor, 20%);
+    color: @textColorlighten20;
     padding: 0.2rem 0.5rem;
     margin: 0;
     color: #ff502c;

--- a/styles/color-schema.less
+++ b/styles/color-schema.less
@@ -1,0 +1,395 @@
+// Badge.vue
+.badge {
+  color: white;
+  background-color: @badgeTipColor !important;
+  &.tip, &.green {
+    background-color: @badgeTipColor !important;
+  }
+  &.error {
+    background-color: @badgeErrorColor !important;
+  }
+  &.warning, &.warn, &.yellow {
+    background-color: @badgeWarningColor !important;
+  }
+}
+
+// Ads.vue
+.ads {
+  #ads_3 {
+    .ads_title {
+      color: #777;
+    }
+  }
+}
+
+// AlgoliaSearchBox.vue
+.algolia-search-wrapper {
+  .algolia-autocomplete {
+    .ds-dropdown-menu {
+      background-color: #fff;
+      &:before {
+        border-color: #999;
+      }
+      .ds-suggestion {
+        border-bottom: 1px solid @borderColor !important;
+      }
+    }
+
+    .algolia-docsearch-suggestion--highlight {
+      color: #2c815b;
+    }
+    .algolia-docsearch-suggestion {
+      border-color: @borderColor !important;
+      .algolia-docsearch-suggestion--category-header {
+        background: @accentColor !important;
+        color: #fff;
+      }
+      .algolia-docsearch-suggestion--title {
+        color: @textColor !important;
+      }
+      .algolia-docsearch-suggestion--subcategory-column {
+        border-color: @borderColor !important;
+      }
+      .algolia-docsearch-suggestion--subcategory-column-text {
+        color: #555;
+      }
+    }
+    .algolia-docsearch-footer {
+      border-color: @borderColor !important;
+    }
+    .ds-cursor .algolia-docsearch-suggestion--content {
+      background-color: #e7edf3 !important;
+      color: @textColor !important;
+    }
+  }
+}
+
+// Home.vue
+.home {
+  .hero {
+    h1{
+      color: @bodyTextColor !important;
+    }
+    .description {
+      color: @bodyTextColor !important;
+    }
+    .action-button {
+      color: #fff;
+      background-color: @accentColor !important;
+      border-bottom: 1px solid @accentColordarken10 !important;
+      &:hover {
+        background-color: @accentColorlighten10 !important;
+      }
+    }
+  }
+  .feature {
+    h2 {
+      color: @bodyTextColorlighten10 !important;
+    }
+
+    p {
+      color: @bodyTextColorlighten10 !important;
+    }
+  }
+}
+
+.footer {
+  background-color: #000;
+  color: rgba(255, 255, 255, 0.4);
+  .footer-container {
+    h2 {
+      color: #fff;
+    }
+    .footer-item {
+      a {
+        color: #fff;
+      }
+      a:hover {
+        color: @accentColor !important;
+      }
+    }
+  }
+}
+
+// Navbar.vue
+.navbar {
+  filter: drop-shadow(0px 1px 1px @dropShadowColor);
+  .site-name {
+    color: @textColor !important;
+  }
+  .links {
+    background-color: white;
+  }
+}
+
+// NavLinks.vue
+.nav-links {
+  .repo-link {
+    color: inherit;
+    &:hover {
+      color: @accentColor !important;
+    }
+  }
+}
+
+// PageEdit.vue
+.page-edit {
+  .edit-link {
+    a {
+      color: @colorTextColor !important;
+    }
+  }
+  .last-updated {
+    .prefix {
+      color: @colorTextColor !important;
+    }
+    .time {
+      color: @accentColor !important;
+    }
+  }
+}
+
+// PageNav.vue
+.page-nav {
+  .inner {
+    border-top: 1px solid @borderColor !important;
+  }
+}
+
+// Sidebar.vue
+.sidebar {
+  border-right: 0.5px solid @borderColorlighten10 !important;
+  & > .sidebar-links {
+    & > li > a.sidebar-link {
+      transition: color 0.25s ease-in-out, border-color 0.25s ease-in-out,
+        background 0.25s ease-in-out;
+    }
+  }
+}
+
+.sidebar {
+  background-color: var(--light);
+  opacity: .8;
+  filter: brightness(.8) contrast(1.2);
+}
+
+.sidebarWrap .mobile-sidebar {
+  background-color: var(--light) !important;
+  opacity: .8;
+  filter: brightness(.8) contrast(1.2);
+}
+
+// SidebarButton.vue
+.sidebar-button {
+  color: #828282;
+}
+
+// SidebarGroup.vue
+.sidebar-group {
+  &:not(.collapsable) {
+    .sidebar-heading:not(.clickable) {
+      color: inherit;
+    }
+  }
+}
+
+.sidebar-heading {
+  color: rgba(0,0,0,.65);
+  transition: color 0.15s ease;
+  transition: color .25s ease-in-out;
+  &.open{
+    color: inherit;
+  }
+  &:hover{
+    color: @accentColor !important;
+  }
+  &.clickable {
+    &.active {
+      color: @accentColor !important;
+      border-left-color: @accentColor !important;
+    }
+    &:hover {
+      color: @accentColor !important;
+    }
+  }
+}
+
+// SidebarLink.vue
+a.sidebar-link {
+  &::after {
+    border-right: 3px solid @accentColor !important;
+  }
+  &:hover {
+    color: @accentColor !important;
+  }
+  &.active {
+    color: @accentColor !important;
+    background-color: @accentColorfade10 !important;
+  }
+  .sidebar-sub-headers & {
+    &.active {
+      background-color: transparent;
+    }
+  }
+}
+
+// body Color
+html,body{
+  background-color: @bodyBgColor !important;
+}
+
+// search
+.search-box {
+  input {
+    border-radius: 2rem !important;
+  }
+}
+
+.sidebar {
+  top: 4.1rem !important;
+}
+
+.ant-row{
+  background-color: @borderColor;
+  transition: background 0.3s cubic-bezier(0.78, 0.14, 0.15, 0.86);
+}
+.ant-menu{
+  background-color: @borderColor;
+}
+.ant-menu-horizontal > .ant-menu-item-selected > a{
+  color: @accentColor !important;
+  font-weight: bolder;
+}
+.ant-menu-horizontal > .ant-menu-item > a:hover{
+  color: @accentColor;
+}
+.ant-menu-horizontal > .ant-menu-item > a{
+  color: @textColor;
+}
+.ant-menu-item > a:hover{
+  color: @accentColor;
+}
+.ant-menu-item > a{
+  color: @textColor;
+}
+.ant-menu-item-selected > a{
+  color: @accentColor;
+  font-weight: bolder;
+}
+.ant-menu:not(.ant-menu-horizontal) > .ant-menu-item-selected{
+  background-color: @borderColordarken5;
+}
+.ant-btn-primary{
+  background-color: @borderColor;
+  border-color: @borderColor;
+}
+.ant-btn-primary:hover {
+  background-color: @borderColor;
+  border-color: @accentColor;
+}
+.ant-btn-primary:focus {
+  background-color: @borderColor;
+  border-color: @borderColor;
+}
+.ant-drawer-wrapper-body {
+  background-color: @borderColordarken5;
+}
+.ant-menu-submenu > .ant-menu {
+  background-color: @borderColor;
+}
+.nav-links .ant-menu-inline {
+  color: @textColor;
+}
+.ant-menu-horizontal > .ant-menu-submenu {
+  color: @textColor;
+}
+.ant-menu-submenu-title:hover {
+  color: @accentColor;
+}
+.ant-menu-horizontal > .ant-menu-submenu-selected {
+  border-bottom: 2px solid @accentColor;
+}
+.nav-links > .repo-link{
+  color: @textColor !important;
+}
+.ant-menu-submenu-selected {
+  color: @accentColor;
+}
+
+.icon.outbound {
+  color: @accentColorlighten10;
+}
+
+hr {
+  border-top: 1px solid @textColor !important;
+}
+
+.icon.outbound {
+  color: @bodyTextColorlighten10 !important;
+}
+.custom-block.tip {
+  border-radius: 6px;
+  color: @textColor !important;
+  background-color: @badgeTipColor !important;
+  // border-color: @badgeTipColor !important;
+}
+.custom-block.warning {
+  border-radius: 6px;
+  color: @textColor !important;
+  background-color: @badgeWarningColor !important;
+  // border-color: @badgeWarningColor !important;
+}
+.custom-block.danger {
+  border-radius: 6px;
+  color: @textColor !important;
+  background-color: @badgeErrorColor !important;
+  // border-color: @badgeErrorColor !important;
+}
+.custom-block.details {
+  border-radius: 6px;
+  color: @textColor !important;
+  background-color: @borderColor !important;
+  // border-color: @borderColor !important;
+}
+
+[data-theme="dark"] .theme-antdocs-content:not(.custom) img {
+  opacity: .8;
+  filter: brightness(.8) contrast(1.2);
+}
+
+[data-theme="dark"] .medium-zoom-image--opened {
+  opacity: .8;
+  filter: brightness(.8) contrast(1.2);
+}
+
+[data-theme="dark"] .theme-container.no-sidebar .page {
+  background-color: @bodyBgColor;
+}
+
+[data-theme="dark"] .theme-container.about-page .page {
+  background-color: @bodyBgColor !important;
+}
+
+[data-theme="dark"] .about-card .card {
+  background-color: unset !important;
+}
+
+[data-theme="dark"] .md-card.show-border {
+  background-color: @bodyBgColor !important;
+}
+
+[data-theme="dark"] .sidebarWrap .drawer-handle {
+  opacity: .8;
+  filter: brightness(.8) contrast(1.2);
+}
+
+.card {
+  color: @textColor !important;
+}
+.about-card .card .actions .button {
+  background-color: @accentColorfade20 !important;
+  color: @accentColor !important;
+}
+.md-card .card-content p, ul, ol {
+  color: @textColor !important;
+}

--- a/styles/index.less
+++ b/styles/index.less
@@ -1,17 +1,20 @@
 @import '~ant-design-vue/dist/antd.less';
 
 @import './palette.less';
+@import './variable.less';
 @import './config.less';
 @import './code.less';
+@import './searchbox.less';
 @import './custom-blocks.less';
 @import './arrow.less';
 @import './wrapper.less';
 @import './toc.less';
 
-@import './searchbox.less';
+
 @import './nprogress.less';
 // @import './pwa.less';
 
+@import './color-schema.less';
 
 html,body {
   padding: 0;

--- a/styles/searchbox.less
+++ b/styles/searchbox.less
@@ -5,7 +5,7 @@
     color: rgba(0, 0, 0, 0.65) !important;
     border-radius: 0 !important;
     border: none !important;
-    border-left: 1px solid darken(@borderColor, 5%) !important;
+    border-left: 1px solid @borderColordarken5 !important;
     line-height: 1.375rem !important;
     padding-left: 2.2rem !important;
     background: #fff url('../assets/search.svg') 0.5rem 0 no-repeat !important;
@@ -24,7 +24,7 @@
     transition: background-color 0.25s ease-in-out, color 0.25s ease-in-out;
 
     &:hover {
-      background-color: fade(@accentColor, 10%) !important;
+      background-color: @accentColorfade10 !important;
     }
 
     a {
@@ -35,7 +35,7 @@
     }
 
     &.focused {
-      background-color: fade(@accentColor, 10%) !important;
+      background-color: @accentColorfade10 !important;
 
       a {
         color: @accentColor !important;
@@ -57,7 +57,7 @@
       }
       &:focus {
         border-color: @accentColor !important;
-        box-shadow: 0 0 0 2px fade(@accentColor, 20%);
+        box-shadow: 0 0 0 2px @accentColorfade20;
       }
     }
   }
@@ -83,7 +83,7 @@
         border-color: @accentColor !important;
         background-size: 1.25rem !important;
         background-position: 0.5rem 0.3rem !important;
-        box-shadow: 0 0 0 2px fade(@accentColor, 20%);
+        box-shadow: 0 0 0 2px @accentColorfade20;
       }
     }
     .suggestions {
@@ -104,7 +104,7 @@
         border-color: @accentColor !important;
         background-size: 1.25rem !important;
         background-position: 0.5rem 0.3rem !important;
-        box-shadow: 0 0 0 2px fade(@accentColor, 20%);
+        box-shadow: 0 0 0 2px @accentColorfade20;
         left: 0.625rem !important;
       }
     }

--- a/styles/variable.less
+++ b/styles/variable.less
@@ -1,0 +1,136 @@
+// colors
+@accentColor: #3eaf7c;
+@primary-color: @accentColor;
+
+@bodyTextColor: rgba(0, 0, 0, 0.8);
+@textColor: #2a2a2a;
+@borderColor: #eaecef;
+@codeBgColor: #282c34;
+@arrowBgColor: #ccc;
+@badgeTipColor: #19be6b;
+@badgeWarningColor: #ff9900;
+@badgeErrorColor: #ed4014;
+
+// colors - light theme
+@accentColor-light: rgba(62, 175, 124, 1);
+@textColor-light: #2c3e50;
+@borderColor-light: #eaecef;
+@codeBgColor-light: #282c34;
+@arrowBgColor-light: #ccc;
+@bodyBgColor-light: #fff;
+@badgeTipColor-light: #e7f1ec;
+@badgeWarningColor-light: #f8f2d1;
+@badgeErrorColor-light: #ffdadc;
+@bodyTextColor-light: rgba(0, 0, 0, 0.8);
+@primary-color-light: #3eaf7c;
+@sideBgColor-light: #fff;
+
+// colors - dark theme
+@accentColor-dark: rgba(245, 34, 45, 1); // rgba(62, 175, 124, 0.8);
+@textColor-dark: #e2e1db;
+@borderColor-dark: #4c525c;
+@codeBgColor-dark: #1a1c22;
+@arrowBgColor-dark: #555;
+@bodyBgColor-dark: rgba(0, 0, 0, 0.25);
+@badgeTipColor-dark: #1b4b35;
+@badgeWarningColor-dark: #574e21;
+@badgeErrorColor-dark: #692025;
+@bodyTextColor-dark: rgba(0, 0, 0, 0.8);
+@primary-color-dark: rgba(0, 0, 0, 0.5);
+@sideBgColor-dark: #363b40;
+
+[data-theme="light"]{
+  --accentColor: @accentColor-light;
+  --accentColordarken10: darken(@accentColor-light, 10%);
+  --accentColorlighten10: lighten(@accentColor-light, 10%);
+  --accentColorfade10: fade(@accentColor-light, 10%);
+  --accentColorfade20: fade(@accentColor-light, 20%);
+  --textColor: @textColor-light;
+  --textColorlighten10: lighten(@textColor-light, 10%);
+  --textColorlighten20: lighten(@textColor-light, 20%);
+  --textColorlighten25: lighten(@textColor-light, 25%);
+  --borderColor: @borderColor-light;
+  --borderColorlighten10: lighten(@borderColor-light, 10%);
+  --borderColordarken5: darken(@borderColor-light, 5%);
+  --codeBgColor: @codeBgColor-light;
+  --arrowBgColor: @arrowBgColor-light;
+  --bodyBgColor: @bodyBgColor-light;
+  --badgeTipColor: @badgeTipColor-light;
+  --badgeWarningColor: @badgeWarningColor-light;
+  --badgeErrorColor: @badgeErrorColor-light;
+  --bodyTextColor: @bodyTextColor-light;
+  --bodyTextColorlighten10: lighten(@bodyTextColor-light, 10%);
+  --sideBgColor: @sideBgColor-light;
+}
+[data-theme="dark"]{
+  --accentColor: @accentColor-dark;
+  --accentColordarken10: darken(@accentColor-dark, 10%);
+  --accentColorlighten10: lighten(@accentColor-dark, 10%);
+  --accentColorfade10: fade(@accentColor-dark, 10%);
+  --accentColorfade20: fade(@accentColor-dark, 20%);
+  --textColor: @textColor-dark;
+  --textColorlighten10: lighten(@textColor-dark, 10%);
+  --textColorlighten20: lighten(@textColor-dark, 20%);
+  --textColorlighten25: lighten(@textColor-dark, 25%);
+  --borderColor: @borderColor-dark;
+  --borderColorlighten10: lighten(@borderColor-dark, 10%);
+  --borderColordarken5: darken(@borderColor-dark, 5%);
+  --codeBgColor: @codeBgColor-dark;
+  --arrowBgColor: @arrowBgColor-dark;
+  --bodyBgColor: @bodyBgColor-dark;
+  --badgeTipColor: @badgeTipColor-dark;
+  --badgeWarningColor: @badgeWarningColor-dark;
+  --badgeErrorColor: @badgeErrorColor-dark;
+  --bodyTextColor: @bodyTextColor-dark;
+  --bodyTextColorlighten10: lighten(@bodyTextColor-dark, 10%);
+  --sideBgColor: @sideBgColor-dark;
+}
+@accentColor: var(--accentColor);
+@accentColordarken10: var(--accentColordarken10);
+@accentColorlighten10: var(--accentColorlighten10);
+@accentColorfade10: var(--accentColorfade10);
+@accentColorfade20: var(--accentColorfade20);
+@textColor: var(--textColor);
+@textColorlighten10: var(--textColorlighten10);
+@textColorlighten20: var(--textColorlighten20);
+@textColorlighten25: var(--textColorlighten25);
+@borderColor: var(--borderColor);
+@borderColorlighten10: var(--borderColorlighten10);
+@borderColordarken5: var(--borderColordarken5);
+@codeBgColor: var(--codeBgColor);
+@arrowBgColor: var(--arrowBgColor);
+@bodyBgColor: var(--bodyBgColor);
+@badgeTipColor: var(--badgeTipColor);
+@badgeWarningColor: var(--badgeWarningColor);
+@badgeErrorColor: var(--badgeErrorColor);
+@bodyTextColor: var(--bodyTextColor);
+@bodyTextColorlighten10: var(--bodyTextColorlighten10);
+@sideBgColor: var(--sideBgColor);
+
+@primary-color: #3eaf7c;
+@dropShadowColor: #111112;
+@colorTextColor: #096dd9;
+
+:root {
+  --blue: #007bff;
+  --indigo: #6610f2;
+  --purple: #6f42c1;
+  --pink: #e83e8c;
+  --red: #dc3545;
+  --orange: #fd7e14;
+  --yellow: #ffc107;
+  --green: #28a745;
+  --teal: #20c997;
+  --cyan: #17a2b8;
+  --white: #fff;
+  --gray: #6c757d;
+  --gray-dark: #343a40;
+  --primary: #007bff;
+  --secondary: #6c757d;
+  --success: #28a745;
+  --info: #17a2b8;
+  --warning: #ffc107;
+  --danger: #dc3545;
+  --light: #f8f9fa;
+  --dark: #343a40;
+}


### PR DESCRIPTION
加入暗色模式，参考vuepress-theme-succinct主题制作，效果参照<https://pxxyyz-dev.github.io/>
- config.js文件需要设置
```
  theme: 'antdocs',
  globalUIComponents: [
    'ThemeManager'
  ],
```
- style文件尽量没有改
- 添加color-schema.less文件，将大多数颜色的设置放进来并`!important`
- 添加variable.less文件，设置了暗色、亮色以及一些基础颜色
- 切换开关插入在Navbar.vue的<ThemeSwitcher />并设置class
- components新加组件ThemeSwitcher.vue，与vuepress-theme-succinct主题一样
- 其他地方有亿点点修改

新人入门，所以很多都写的不规范，作者大大还请帮忙看看:smile: